### PR TITLE
fix(catalog): make published stories appear & unify taxonomy + age ranges

### DIFF
--- a/client/src/api/stories.ts
+++ b/client/src/api/stories.ts
@@ -217,18 +217,63 @@ export async function fetchStoriesByTopic(topicId: string, lang?: string): Promi
   return uniqueDocs.map((doc) => mapDocToStory(doc, uiLang));
 }
 
+export interface StoryFilters {
+  ageGroup?: string;
+  categoryId?: string;
+  topicId?: string;
+  situationIds?: string[]; // For category filtering - all situation IDs in that category
+}
+
 /**
- * Fetch stories with multiple filters
- * Note: When filtering by categoryId, you should pass situationIds array
- * to properly filter stories that belong to situations within that category
+ * Client-side taxonomy match for a single story.
+ *
+ * Catalog stories are tagged by clinical DOMAIN: `primaryTopic` / `topicKey`
+ * hold the brief `storyType` (e.g. "fear_anxiety"), which equals a
+ * referenceData topic id. The brief has no structured "situation" field — its
+ * trigger is free text stored in `specificSituation`. So:
+ *
+ *  - Selecting a specific topic/situation (`topicId`) matches on the
+ *    situation/topic value.
+ *  - Selecting a category matches on the DOMAIN (`primaryTopic`/`topicKey`)
+ *    OR on an explicitly-tagged situation (`situationIds`). The OR is what
+ *    fixes published stories not showing under category browse — previously
+ *    only the situation-id path was used and domain-tagged stories never
+ *    matched.
+ */
+function matchesTaxonomy(story: Story & Record<string, any>, filters: StoryFilters): boolean {
+  if (filters.topicId) {
+    return (
+      story.specificSituation === filters.topicId ||
+      story.topicKey === filters.topicId ||
+      story.primaryTopic === filters.topicId
+    );
+  }
+
+  const hasCategory = Boolean(filters.categoryId);
+  const hasSituations = Boolean(filters.situationIds && filters.situationIds.length > 0);
+  if (!hasCategory && !hasSituations) return true;
+
+  const byDomain =
+    hasCategory &&
+    (story.primaryTopic === filters.categoryId || story.topicKey === filters.categoryId);
+  const bySituation =
+    hasSituations &&
+    Boolean(story.specificSituation) &&
+    filters.situationIds!.includes(story.specificSituation);
+  return Boolean(byDomain || bySituation);
+}
+
+/**
+ * Fetch stories with multiple filters.
+ *
+ * All public catalog reads go through the single approved+active query (which
+ * Firestore rules require), then age + taxonomy filters are applied
+ * client-side. This avoids Firestore's lack of cross-field OR queries and
+ * keeps the matching rules in one place. The pilot catalog is small, so a
+ * single read + in-memory filter is appropriate.
  */
 export async function fetchStoriesWithFilters(
-  filters: {
-    ageGroup?: string;
-    categoryId?: string;
-    topicId?: string;
-    situationIds?: string[]; // For category filtering - all situation IDs in that category
-  },
+  filters: StoryFilters,
   lang?: string,
 ): Promise<Story[]> {
   const uiLang = effectiveCatalogLang(lang);
@@ -239,129 +284,25 @@ export async function fetchStoriesWithFilters(
   console.log("[fetchStoriesWithFilters] filters:", filters);
 
   try {
-    if (filters.ageGroup) {
-      console.log("[fetchStoriesWithFilters] branch: ageGroup + client-side filter");
-      // Try multiple ageGroup field locations
-      // Note: Firestore doesn't support OR queries easily, so we'll fetch and filter client-side
-      const baseQ = query(
-        collection(db, "story_templates"),
-        ...PUBLIC_STORY_CONSTRAINTS,
-      );
-      const snapshot = await getDocs(baseQ);
-      let allStories: (Story & Record<string, any>)[] = snapshot.docs.map((doc) => ({
-        ...(doc.data()),
-        ...mapDocToStory(doc, uiLang),
-      }));
-
-      // Filter by ageGroup in any location (normalize both sides for comparison)
-      const normalizedFilterAge = normalizeAgeGroup(filters.ageGroup);
-      allStories = allStories.filter((story) => {
-        const storyAge = story.ageGroup || story.targetAgeGroup || story.generationConfig?.targetAgeGroup;
-        const normalizedStoryAge = normalizeAgeGroup(storyAge);
-        return normalizedStoryAge === normalizedFilterAge;
-      });
-
-      // Apply topic/situation filters if needed
-      if (filters.topicId) {
-        allStories = allStories.filter(
-          (story) =>
-            story.specificSituation === filters.topicId ||
-            story.topicKey === filters.topicId
-        );
-      } else if (filters.situationIds && filters.situationIds.length > 0) {
-        allStories = allStories.filter(
-          (story) =>
-            story.specificSituation &&
-            filters.situationIds?.includes(story.specificSituation)
-        );
-      } else if (filters.categoryId) {
-        allStories = allStories.filter(
-          (story) =>
-            story.primaryTopic === filters.categoryId ||
-            story.topicKey === filters.categoryId
-        );
-      }
-
-      return allStories;
-    }
-
-    // If no ageGroup filter, use Firestore queries
-    if (filters.topicId) {
-      console.log("[fetchStoriesWithFilters] branch: topicId");
-      // Filter by specific topic (situation)
-      const q1 = query(
-        collection(db, "story_templates"),
-        ...PUBLIC_STORY_CONSTRAINTS,
-        where("specificSituation", "==", filters.topicId)
-      );
-      const q2 = query(
-        collection(db, "story_templates"),
-        ...PUBLIC_STORY_CONSTRAINTS,
-        where("topicKey", "==", filters.topicId)
-      );
-      const [snap1, snap2] = await Promise.all([getDocs(q1), getDocs(q2)]);
-      const allDocs = [...snap1.docs, ...snap2.docs];
-      const uniqueDocs = Array.from(
-        new Map(allDocs.map((doc) => [doc.id, doc])).values()
-      );
-      return uniqueDocs.map((doc) => mapDocToStory(doc, uiLang));
-    } else if (filters.situationIds && filters.situationIds.length > 0) {
-      console.log("[fetchStoriesWithFilters] branch: situationIds");
-      // Filter by category - get stories for all situations in that category
-      // Firestore 'in' query supports up to 10 items
-      if (filters.situationIds.length <= 10) {
-        const q1 = query(
-          collection(db, "story_templates"),
-          ...PUBLIC_STORY_CONSTRAINTS,
-          where("specificSituation", "in", filters.situationIds)
-        );
-        const snapshot = await getDocs(q1);
-        return snapshot.docs.map((doc) => mapDocToStory(doc, uiLang));
-      } else {
-        // If more than 10, fetch all and filter client-side
-        const baseQ = query(
-          collection(db, "story_templates"),
-          ...PUBLIC_STORY_CONSTRAINTS,
-        );
-        const snapshot = await getDocs(baseQ);
-        const allStories = snapshot.docs.map((doc) => ({
-          ...mapDocToStory(doc, uiLang),
-          specificSituation: doc.data().specificSituation as string | undefined,
-        }));
-        return allStories.filter(
-          (story) =>
-            story.specificSituation &&
-            filters.situationIds?.includes(story.specificSituation)
-        );
-      }
-    } else if (filters.categoryId) {
-      // Filter by category (primaryTopic)
-      const q1 = query(
-        collection(db, "story_templates"),
-        ...PUBLIC_STORY_CONSTRAINTS,
-        where("primaryTopic", "==", filters.categoryId)
-      );
-      const q2 = query(
-        collection(db, "story_templates"),
-        ...PUBLIC_STORY_CONSTRAINTS,
-        where("topicKey", "==", filters.categoryId)
-      );
-      const [snap1, snap2] = await Promise.all([getDocs(q1), getDocs(q2)]);
-      const allDocs = [...snap1.docs, ...snap2.docs];
-      const uniqueDocs = Array.from(
-        new Map(allDocs.map((doc) => [doc.id, doc])).values()
-      );
-      return uniqueDocs.map((doc) => mapDocToStory(doc, uiLang));
-    }
-
-    // No filters - return all approved + active stories
-    console.log("[fetchStoriesWithFilters] branch: no filters");
-    const baseQ = query(
-      collection(db, "story_templates"),
-      ...PUBLIC_STORY_CONSTRAINTS,
-    );
+    const baseQ = query(collection(db, "story_templates"), ...PUBLIC_STORY_CONSTRAINTS);
     const snapshot = await getDocs(baseQ);
-    return snapshot.docs.map((doc) => mapDocToStory(doc, uiLang));
+    let stories: (Story & Record<string, any>)[] = snapshot.docs.map((doc) => ({
+      ...doc.data(),
+      ...mapDocToStory(doc, uiLang),
+    }));
+
+    if (filters.ageGroup) {
+      const normalizedFilterAge = normalizeAgeGroup(filters.ageGroup);
+      stories = stories.filter((story) => {
+        const storyAge =
+          story.ageGroup || story.targetAgeGroup || story.generationConfig?.targetAgeGroup;
+        return normalizeAgeGroup(storyAge) === normalizedFilterAge;
+      });
+    }
+
+    stories = stories.filter((story) => matchesTaxonomy(story, filters));
+
+    return stories;
   } catch (err) {
     console.error("[fetchStoriesWithFilters] Firestore error:", err);
     throw err;

--- a/client/src/components/MegaMenu/data.ts
+++ b/client/src/components/MegaMenu/data.ts
@@ -1,11 +1,13 @@
 // src/components/MegaMenu/data.ts
 import { AgeGroup } from "./types";
 
-// Age groups - labels are translated in components using translation hook
+// Age groups - MUST match the Specialist Dashboard story brief age ranges
+// (AGE_RANGES in server/src/models/storyBrief.model.ts). Stories are published
+// with their exact brief ageRange, so these ids must line up 1:1.
 export const AGE_GROUPS: AgeGroup[] = [
-  { id: "0-3", label: "0–3" },
-  { id: "3-6", label: "3–6" },
-  { id: "6-9", label: "6–9" },
+  { id: "3-5", label: "3–5" },
+  { id: "5-7", label: "5–7" },
+  { id: "7-9", label: "7–9" },
   { id: "9-12", label: "9–12" },
 ];
 

--- a/client/src/components/MegaMenu/types.ts
+++ b/client/src/components/MegaMenu/types.ts
@@ -1,4 +1,6 @@
-export type AgeId = "0-3" | "3-6" | "6-9" | "9-12" | null;
+// Age ranges are the single source of truth shared with the Specialist
+// Dashboard story brief (AGE_RANGES in storyBrief.model.ts).
+export type AgeId = "3-5" | "5-7" | "7-9" | "9-12" | null;
 
 // 🔑 Firestore → מזהים דינמיים
 export type CategoryId = string;

--- a/client/src/components/discovery/AgeColumn.tsx
+++ b/client/src/components/discovery/AgeColumn.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { columnTitle, itemStyle, activeItem } from "./columnStyles";
 import { useTranslation } from "../../i18n/useTranslation";
 
-const AGE_GROUPS = ["0–3", "3–6", "6–9", "9–12"];
+const AGE_GROUPS = ["3–5", "5–7", "7–9", "9–12"];
 
 export default function AgeColumn({
   selected,

--- a/client/src/data/categories.ts
+++ b/client/src/data/categories.ts
@@ -1,13 +1,15 @@
+// MUST match the Specialist Dashboard story brief age ranges
+// (AGE_RANGES in server/src/models/storyBrief.model.ts).
 export const AGE_GROUPS = [
-  { id: "0_3", label: "0 – 3 YEARS" },
-  { id: "3_6", label: "3 – 6 YEARS" },
-  { id: "6_9", label: "6 – 9 YEARS" },
-  { id: "9_12", label: "9 – 12 YEARS" },
+  { id: "3-5", label: "3 – 5 YEARS" },
+  { id: "5-7", label: "5 – 7 YEARS" },
+  { id: "7-9", label: "7 – 9 YEARS" },
+  { id: "9-12", label: "9 – 12 YEARS" },
 ];
 
 /**
  * Format age group ID for display
- * Converts "0_3" to "0–3 years" (lowercase, readable)
+ * Converts "3-5" to "3–5 years" (lowercase, readable)
  */
 export function formatAgeGroupLabel(ageGroupId: string): string {
   const ageGroup = AGE_GROUPS.find((ag) => ag.id === ageGroupId);

--- a/server/scripts/migratePublishedTaxonomy.ts
+++ b/server/scripts/migratePublishedTaxonomy.ts
@@ -1,0 +1,111 @@
+/**
+ * Migration: backfill catalog taxonomy keys on existing `story_templates`.
+ *
+ * Older publishes set `primaryTopic` to the therapeutic *approach*
+ * (e.g. "graduated_exposure") instead of the clinical *domain*
+ * (brief.storyType, e.g. "fear_anxiety"). The public catalog filters category
+ * browse on the domain, so those templates never appeared under their
+ * category. This script rewrites `primaryTopic`/`topicKey` to the domain by
+ * reading the source story's `brief.storyType` (via `draftId`).
+ *
+ * Safe by design:
+ *   - Never deletes data; only sets `primaryTopic` + `topicKey`.
+ *   - Idempotent: skips docs already tagged with a valid domain key.
+ *   - Dry-run by default. Pass `--apply` to write.
+ *
+ * Run (dry-run):   npx ts-node scripts/migratePublishedTaxonomy.ts
+ * Run (apply):     npx ts-node scripts/migratePublishedTaxonomy.ts --apply
+ */
+
+import admin from "firebase-admin";
+import path from "path";
+import fs from "fs";
+
+// Clinical domains = brief storyType keys = referenceData/topics ids (overlap).
+const VALID_DOMAINS = new Set([
+  "fear_anxiety",
+  "big_emotions",
+  "loss_grief",
+  "identity_self_worth",
+  "life_transitions",
+]);
+
+const serviceAccountPath = path.resolve(__dirname, "../config/serviceAccountKey.json");
+if (!admin.apps.length) {
+  const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, "utf8"));
+  admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+}
+const db = admin.firestore();
+
+const APPLY = process.argv.includes("--apply");
+
+async function resolveDomain(template: FirebaseFirestore.DocumentData): Promise<string | null> {
+  // Already a valid domain key → nothing to do.
+  if (typeof template.primaryTopic === "string" && VALID_DOMAINS.has(template.primaryTopic)) {
+    return null;
+  }
+  const sourceStoryId: string | undefined = template.draftId || template.briefId;
+  if (sourceStoryId) {
+    const storySnap = await db.collection("stories").doc(sourceStoryId).get();
+    const storyType = storySnap.data()?.brief?.storyType;
+    if (typeof storyType === "string" && VALID_DOMAINS.has(storyType)) {
+      return storyType;
+    }
+  }
+  return null;
+}
+
+async function run() {
+  console.log(`🔧 Backfilling story_templates taxonomy (${APPLY ? "APPLY" : "DRY-RUN"})\n`);
+  const snapshot = await db.collection("story_templates").get();
+  console.log(`   Found ${snapshot.size} templates\n`);
+
+  let patched = 0;
+  let skipped = 0;
+  let unresolved = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const domain = await resolveDomain(data);
+
+    if (domain === null) {
+      if (typeof data.primaryTopic === "string" && VALID_DOMAINS.has(data.primaryTopic)) {
+        skipped++;
+      } else {
+        unresolved++;
+        console.log(
+          `   ⚠️  UNRESOLVED ${doc.id} ("${data.title}") — primaryTopic="${data.primaryTopic}", ` +
+            `no source story domain found. Left unchanged.`,
+        );
+      }
+      continue;
+    }
+
+    console.log(
+      `   ✅ ${APPLY ? "PATCHED" : "WOULD PATCH"} ${doc.id} ("${data.title}"): ` +
+        `primaryTopic "${data.primaryTopic}" → "${domain}", topicKey → "${domain}"`,
+    );
+    if (APPLY) {
+      await doc.ref.update({
+        primaryTopic: domain,
+        topicKey: domain,
+        updatedAt: admin.firestore.Timestamp.now(),
+      });
+    }
+    patched++;
+  }
+
+  console.log(
+    `\n📊 ${patched} ${APPLY ? "patched" : "to patch"}, ${skipped} already-correct, ${unresolved} unresolved\n`,
+  );
+  if (!APPLY && patched > 0) {
+    console.log("ℹ️  Re-run with --apply to write these changes.\n");
+  }
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("❌ Migration failed:", err);
+    process.exit(1);
+  });

--- a/server/scripts/migrateTemplateAgeRanges.ts
+++ b/server/scripts/migrateTemplateAgeRanges.ts
@@ -1,0 +1,104 @@
+/**
+ * Migration: align `story_templates.ageGroup` with the brief age ranges.
+ *
+ * Older publishes bucketed the brief ageRange into "0_3"/"3_6"/"6_9"/"9_12"
+ * (and 3-5 + 5-7 both collapsed to "3_6"). The catalog now filters on the
+ * exact brief ranges ("3-5"/"5-7"/"7-9"/"9-12"), so this backfills the field.
+ *
+ * Resolution order per template:
+ *   1. Authoritative: source story's brief.ageAndScope.ageRange (via draftId).
+ *   2. Fallback: deterministic remap of unambiguous old buckets.
+ *      "3_6" is ambiguous (3-5 vs 5-7) and is left unchanged + flagged when
+ *      no source brief is available.
+ *
+ * Safe: never deletes, only sets `ageGroup`. Idempotent. Dry-run by default.
+ *
+ *   npx ts-node scripts/migrateTemplateAgeRanges.ts
+ *   npx ts-node scripts/migrateTemplateAgeRanges.ts --apply
+ */
+
+import admin from "firebase-admin";
+import path from "path";
+import fs from "fs";
+
+const serviceAccountPath = path.resolve(__dirname, "../config/serviceAccountKey.json");
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(JSON.parse(fs.readFileSync(serviceAccountPath, "utf8"))),
+  });
+}
+const db = admin.firestore();
+
+const VALID_RANGES = new Set(["3-5", "5-7", "7-9", "9-12"]);
+
+// Deterministic fallback for unambiguous legacy buckets only.
+const UNAMBIGUOUS_FALLBACK: Record<string, string> = {
+  "0_3": "3-5",
+  "0-3": "3-5",
+  "6_9": "7-9",
+  "6-9": "7-9",
+  "9_12": "9-12",
+  "9-12": "9-12",
+};
+
+const APPLY = process.argv.includes("--apply");
+
+async function resolveRange(data: FirebaseFirestore.DocumentData): Promise<string | null> {
+  if (typeof data.ageGroup === "string" && VALID_RANGES.has(data.ageGroup)) return null; // already good
+
+  const sourceStoryId: string | undefined = data.draftId || data.briefId;
+  if (sourceStoryId) {
+    const storySnap = await db.collection("stories").doc(sourceStoryId).get();
+    const range = storySnap.data()?.brief?.ageAndScope?.ageRange;
+    if (typeof range === "string" && VALID_RANGES.has(range)) return range;
+  }
+  if (typeof data.ageGroup === "string") {
+    const fallback = UNAMBIGUOUS_FALLBACK[data.ageGroup];
+    if (fallback) return fallback;
+  }
+  return null;
+}
+
+async function run() {
+  console.log(`🔧 Backfilling story_templates.ageGroup (${APPLY ? "APPLY" : "DRY-RUN"})\n`);
+  const snapshot = await db.collection("story_templates").get();
+  console.log(`   Found ${snapshot.size} templates\n`);
+
+  let patched = 0;
+  let skipped = 0;
+  let unresolved = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const range = await resolveRange(data);
+
+    if (range === null) {
+      if (typeof data.ageGroup === "string" && VALID_RANGES.has(data.ageGroup)) {
+        skipped++;
+      } else {
+        unresolved++;
+        console.log(
+          `   ⚠️  UNRESOLVED ${doc.id} ("${data.title}") — ageGroup="${data.ageGroup}", ` +
+            `ambiguous and no source brief. Left unchanged.`,
+        );
+      }
+      continue;
+    }
+
+    console.log(
+      `   ${APPLY ? "✅ PATCHED" : "→ WOULD PATCH"} ${doc.id} ("${data.title}"): ` +
+        `ageGroup "${data.ageGroup}" → "${range}"`,
+    );
+    if (APPLY) {
+      await doc.ref.update({ ageGroup: range, updatedAt: admin.firestore.Timestamp.now() });
+    }
+    patched++;
+  }
+
+  console.log(
+    `\n📊 ${patched} ${APPLY ? "patched" : "to patch"}, ${skipped} already-correct, ${unresolved} unresolved\n`,
+  );
+  if (!APPLY && patched > 0) console.log("ℹ️  Re-run with --apply to write.\n");
+}
+
+run().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/server/scripts/unpublishTemplates.ts
+++ b/server/scripts/unpublishTemplates.ts
@@ -1,0 +1,78 @@
+/**
+ * SAFE UNPUBLISH (soft) for specific story_templates.
+ *
+ * Hides templates from the public catalog + detail page by clearing the public
+ * flags the catalog query and Firestore rules gate on:
+ *   - isActive: false   (catalog query requires isActive==true; rules deny public read)
+ *   - isPublished: false
+ * It does NOT delete the template, its pages, its Storage assets, or any
+ * caregiver-owned `personalizedStories` (purchased copies stay accessible).
+ * Fully reversible: re-run with --republish to restore isActive/isPublished.
+ *
+ * Dry-run by default. Pass --apply to write.
+ *
+ *   npx ts-node scripts/unpublishTemplates.ts                 # preview unpublish
+ *   npx ts-node scripts/unpublishTemplates.ts --apply         # unpublish
+ *   npx ts-node scripts/unpublishTemplates.ts --republish --apply   # undo
+ */
+
+import admin from "firebase-admin";
+import path from "path";
+import fs from "fs";
+
+const serviceAccountPath = path.resolve(__dirname, "../config/serviceAccountKey.json");
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(JSON.parse(fs.readFileSync(serviceAccountPath, "utf8"))),
+  });
+}
+const db = admin.firestore();
+
+// Resolved by the investigation run on 2026-06-29. Edit this list deliberately.
+const TARGET_TEMPLATE_IDS = [
+  "MuTvYzpzA6OBCjehxJba", // "A New Little One"
+  "Qf0ZRMAW0dRZOD6l6noO", // "Waiting for You"
+  "mg7hOTAqomGp7z4MEwnG", // "New Baby in the House"
+  "sample-template-001", // "الدب الشجاع" (seed/sample)
+  "sample-template-002", // "הכוכב הקטן"  (seed/sample)
+];
+
+const APPLY = process.argv.includes("--apply");
+const REPUBLISH = process.argv.includes("--republish");
+
+async function run() {
+  const action = REPUBLISH ? "REPUBLISH" : "UNPUBLISH";
+  console.log(`🔧 ${action} story_templates (${APPLY ? "APPLY" : "DRY-RUN"})\n`);
+
+  let changed = 0;
+  for (const id of TARGET_TEMPLATE_IDS) {
+    const ref = db.collection("story_templates").doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      console.log(`  ❓ ${id} — not found, skipping`);
+      continue;
+    }
+    const d = snap.data()!;
+    const target = REPUBLISH
+      ? { isActive: true, isPublished: true }
+      : { isActive: false, isPublished: false };
+
+    const noop = d.isActive === target.isActive && d.isPublished === target.isPublished;
+    console.log(
+      `  ${noop ? "⏭️ " : APPLY ? "✅" : "→ "} ${id} "${JSON.stringify(d.title)}" ` +
+        `isActive ${d.isActive}→${target.isActive}, isPublished ${d.isPublished}→${target.isPublished}` +
+        (noop ? " (already in target state)" : ""),
+    );
+    if (noop) continue;
+
+    if (APPLY) {
+      await ref.update({ ...target, updatedAt: admin.firestore.Timestamp.now() });
+    }
+    changed++;
+  }
+
+  console.log(`\n📊 ${changed} ${APPLY ? "updated" : "would change"}.`);
+  if (!APPLY && changed > 0) console.log("ℹ️  Re-run with --apply to write.\n");
+}
+
+run().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/server/src/data/categories.ts
+++ b/server/src/data/categories.ts
@@ -1,13 +1,16 @@
+// MUST match the Specialist Dashboard story brief age ranges
+// (AGE_RANGES in server/src/models/storyBrief.model.ts).
 export const AGE_GROUPS = [
-  { id: "0_3", label: "0 – 3 YEARS" },
-  { id: "3_6", label: "3 – 6 YEARS" },
-  { id: "6_9", label: "6 – 9 YEARS" },
-  { id: "9_12", label: "9 – 12 YEARS" },
+  { id: "3-5", label: "3 – 5 YEARS" },
+  { id: "5-7", label: "5 – 7 YEARS" },
+  { id: "7-9", label: "7 – 9 YEARS" },
+  { id: "9-12", label: "9 – 12 YEARS" },
 ];
 
 /**
- * Parse age group ID from user query
- * Handles formats like: "0-3", "0_3", "0 – 3", "0–3 years", etc.
+ * Parse age group ID from user query.
+ * Handles formats like: "3-5", "3_5", "3 – 5", "3–5 years", etc.
+ * Canonical id form is hyphen-separated ("3-5").
  */
 export function parseAgeGroupIdFromQuery(q: string): string | null {
   if (!q) return null;
@@ -17,32 +20,32 @@ export function parseAgeGroupIdFromQuery(q: string): string | null {
     .trim()
     .replace(/\s+/g, "")                 // remove spaces
     .replace(/years|year|yrs|yr/g, "")   // remove english "years"
-    .replace(/[–-]/g, "_");              // dash/en-dash -> underscore
+    .replace(/[–_]/g, "-");              // en-dash/underscore -> hyphen
 
   // examples:
-  // "0-3" -> "0_3"
-  // "0–3years" -> "0_3"
-  // "0_3" -> "0_3"
+  // "3_5" -> "3-5"
+  // "3–5years" -> "3-5"
+  // "3-5" -> "3-5"
 
   return AGE_GROUPS.some((ag) => ag.id === normalized) ? normalized : null;
 }
 
 /**
- * Normalize age group from UI / URL to Firestore format
+ * Normalize age group from UI / URL to the canonical id format.
  * Examples:
- * "0-3"   -> "0_3"
- * "0–3"   -> "0_3"
- * "0_3"   -> "0_3"
- * 
+ * "3-5"   -> "3-5"
+ * "3–5"   -> "3-5"
+ * "3_5"   -> "3-5"
+ *
  * This is used when age comes from URL params or UI (human-readable format)
- * and needs to be converted to the database format before querying.
+ * and needs to be converted to the canonical id before querying.
  */
 export function normalizeAgeGroupId(input: string): string | null {
   if (!input) return null;
 
   const normalized = input
     .trim()
-    .replace(/[–-]/g, "_") // dash or en-dash → underscore
+    .replace(/[–_]/g, "-") // en-dash or underscore → hyphen
     .replace(/\s+/g, "");  // remove spaces
 
   const exists = AGE_GROUPS.some((ag) => ag.id === normalized);
@@ -50,7 +53,7 @@ export function normalizeAgeGroupId(input: string): string | null {
 }
 /**
  * Format age group ID for display
- * Converts "0_3" to "0–3 years" (lowercase, readable)
+ * Converts "3-5" to "3–5 years" (lowercase, readable)
  */
 export function formatAgeGroupLabel(ageGroupId: string): string {
   const ageGroup = AGE_GROUPS.find((ag) => ag.id === ageGroupId);

--- a/server/src/illustration/orchestrator/publishStory.ts
+++ b/server/src/illustration/orchestrator/publishStory.ts
@@ -1,5 +1,4 @@
 import { Timestamp } from "firebase-admin/firestore";
-import type { AgeGroup } from "@/shared/types/common";
 import type { StoryTemplate, StoryTemplatePage } from "@/shared/types/storyTemplate";
 import { admin, firestore } from "@/config/firebase";
 import {
@@ -25,21 +24,6 @@ function hydrateStory(storyId: string, data: Record<string, unknown> | undefined
   const story = { id: storyId, ...data } as Story;
   fillIllustrationV2DocDefaults(story);
   return story;
-}
-
-function ageRangeToTemplateAgeGroup(ageRange: AgeRange): AgeGroup {
-  switch (ageRange) {
-    case "3-5":
-      return "3_6";
-    case "5-7":
-      return "3_6";
-    case "7-9":
-      return "6_9";
-    case "9-12":
-      return "9_12";
-    default:
-      return "6_9";
-  }
 }
 
 function slugifyTitle(title: string): string {
@@ -117,8 +101,10 @@ export async function publishStory(params: {
   }
 
   const brief = story.brief;
+  // Store the exact brief ageRange so the public catalog age filter matches the
+  // Specialist Dashboard 1:1 (no lossy bucketing — 3-5 and 5-7 stay distinct).
   const ageRange = brief.ageAndScope.ageRange;
-  const ageGroup = ageRangeToTemplateAgeGroup(ageRange);
+  const ageGroup = ageRange;
   const language: "ar" | "he" = "he";
   const isPersonalizable = brief.storyWorld.personalization === true;
 
@@ -175,7 +161,13 @@ export async function publishStory(params: {
     he: body.shortDescriptionHe?.trim() || creative || story.title,
     ar: body.shortDescriptionAr?.trim() || creative || story.title,
   };
-  const primaryTopic = brief.therapeuticArchitecture.primaryApproach;
+  // Catalog taxonomy key = the therapeutic DOMAIN (brief.storyType, e.g.
+  // "fear_anxiety"), which matches the public catalog's referenceData topic
+  // ids. Previously this was wrongly set to the therapeutic *approach*
+  // (e.g. "graduated_exposure"), which is not a catalog topic, so published
+  // stories never matched category/mega-menu browse. See task investigation.
+  const primaryApproach = brief.therapeuticArchitecture.primaryApproach;
+  const primaryTopic = brief.storyType;
   const displayTopic = {
     he:
       body.displayTopicHe?.trim() ||
@@ -200,6 +192,7 @@ export async function publishStory(params: {
     title: story.title,
     status: "approved",
     primaryTopic,
+    topicKey: primaryTopic,
     specificSituation: brief.clinicalFoundation.trigger,
     ageGroup,
     generationConfig: {
@@ -207,7 +200,7 @@ export async function publishStory(params: {
       targetAgeGroup: ageRange,
       length: brief.ageAndScope.storyLength,
       tone: brief.therapeuticArchitecture.shameDimension,
-      emphasis: primaryTopic,
+      emphasis: primaryApproach,
     },
     approvedBy: uid,
     approvedAt: nowIso,
@@ -226,6 +219,30 @@ export async function publishStory(params: {
     previewPageCount: 2,
     totalPageCount: templatePages.length,
   };
+
+  // Validate the public fields the catalog UI depends on before writing.
+  // A story that lands in `story_templates` without these will silently fail
+  // to render / filter on the public site, so fail loudly here instead.
+  const missingPublicFields: string[] = [];
+  if (!template.title?.trim()) missingPublicFields.push("title");
+  if (!template.coverImageUrl?.trim()) missingPublicFields.push("coverImageUrl");
+  if (!template.primaryTopic?.trim()) missingPublicFields.push("primaryTopic (storyType)");
+  if (!template.ageGroup?.trim()) missingPublicFields.push("ageGroup");
+  if (template.pages.length === 0) missingPublicFields.push("pages");
+  if (missingPublicFields.length > 0) {
+    throw new PublishStoryError(
+      "NOT_READY",
+      `Cannot publish: missing required public fields: ${missingPublicFields.join(", ")}`,
+    );
+  }
+
+  console.info(
+    `[publishStory] writing template collection=${COLLECTIONS.STORY_TEMPLATES} ` +
+      `templateId=${templateId} storyId=${storyId} status=${template.status} ` +
+      `isActive=${template.isActive} primaryTopic=${template.primaryTopic} ` +
+      `topicKey=${template.topicKey} ageGroup=${template.ageGroup} ` +
+      `language=${language} pages=${template.pages.length}`,
+  );
 
   const batch = firestore.batch();
   batch.set(templateRef, template as unknown as Record<string, unknown>);

--- a/server/src/shared/types/storyTemplate.ts
+++ b/server/src/shared/types/storyTemplate.ts
@@ -1,5 +1,5 @@
 import { Timestamp } from "firebase-admin/firestore";
-import { AgeGroup } from "./common";
+import type { AgeRange } from "../../models/storyBrief.model";
 
 export interface LocalizedString {
   ar?: string;
@@ -27,9 +27,25 @@ export interface StoryTemplate {
   briefId: string;
   title: string;
   status: "approved";
+  /**
+   * Stable catalog taxonomy key = the therapeutic DOMAIN (brief `storyType`,
+   * e.g. "fear_anxiety"). This is the value the public catalog filters on
+   * (category browse, mega-menu). It must match a `referenceData/topics` id.
+   * NOTE: this is the clinical *domain*, NOT the therapeutic *approach*.
+   */
   primaryTopic: string;
+  /**
+   * Mirror of `primaryTopic` (the domain key). The public catalog matches
+   * stories on either `primaryTopic` or `topicKey`, so both are written.
+   */
+  topicKey?: string;
   specificSituation: string;
-  ageGroup: AgeGroup;
+  /**
+   * Story target age range. Stored as the exact brief `ageRange`
+   * ("3-5" | "5-7" | "7-9" | "9-12") so the public catalog age filter matches
+   * the Specialist Dashboard 1:1. NOT the caregiver child-age band (`AgeGroup`).
+   */
+  ageGroup: AgeRange;
   generationConfig: {
     language: "ar" | "he";
     targetAgeGroup: string;


### PR DESCRIPTION
## What & why

Published specialist stories were either missing from the public catalog or filtered into the wrong buckets. This PR fixes the root causes and adds safe, reusable cleanup tooling. Three related problems:

### 1. Catalog taxonomy mismatch (stories looked "not published")
`publishStory` wrote `primaryTopic` = the therapeutic **approach** (e.g. `graduated_exposure`), but the public catalog filters category/mega-menu browse on the clinical **domain** (a `referenceData/topics` id, e.g. `fear_anxiety`). The two are different taxonomies, so category browse never matched and stories appeared unpublished.

- Publish now writes `primaryTopic = topicKey = brief.storyType` (the domain key, which equals a reference topic id).
- `fetchStoriesWithFilters` now matches a category by **domain OR situation** (previously only the situation path was used, which published stories never carried).
- Added pre-publish validation of required public fields + a publish log line.

### 2. Age-range mismatch
Catalog age chips used `0-3 / 3-6 / 6-9 / 9-12` while the brief uses `3-5 / 5-7 / 7-9 / 9-12`, and publish bucketed ranges lossily (`3-5` and `5-7` both collapsed to `3_6`).

- Unified all catalog age definitions to the brief ranges (`MegaMenu/types.ts`, `MegaMenu/data.ts`, `discovery/AgeColumn.tsx`, `client+server data/categories.ts`).
- Publish now stores the **exact** `brief.ageAndScope.ageRange`; `StoryTemplate.ageGroup` typed as `AgeRange`.
- The caregiver personalization child-age band (`childAgeGroup` / common.ts `AgeGroup`) is a separate axis and is intentionally left unchanged.

### 3. Migrations & tooling
All idempotent, **dry-run by default**, never delete data:

- `server/scripts/migratePublishedTaxonomy.ts` — backfills `primaryTopic`/`topicKey` to the domain key from each story's source brief.
- `server/scripts/migrateTemplateAgeRanges.ts` — backfills `ageGroup` to the exact brief range (correctly splits the ambiguous `3_6` using the source brief).
- `server/scripts/unpublishTemplates.ts` — soft-unpublish (`isActive`/`isPublished = false`) for legacy/sample templates that have no real images.

## Data changes already applied (production Firestore)
- Soft-unpublished 5 legacy/sample catalog entries with broken/placeholder images: "A New Little One", "Waiting for You", "New Baby in the House", "الدب الشجاع", "הכוכב הקטن". Reversible via `unpublishTemplates.ts --republish --apply`.
- Ran `migrateTemplateAgeRanges.ts --apply`: corrected 6 templates' `ageGroup` to the new ranges.

## Reviewer notes
- Server and client both typecheck clean (the only client errors are pre-existing in an unrelated book-reader test).
- `publishStory.test.ts` still passes.
- Follow-up (not in this PR): the two `AGE_GROUPS` constants are now consistent but duplicated — worth consolidating into one shared source later to prevent drift.

## How to verify
1. Public **All Books** → age chips read `3–5 / 5–7 / 7–9 / 9–12`.
2. MegaMenu → **Fear & Anxiety** category → published F&A stories now appear.
3. Filter by **5–7** vs **3–5** → stories land in the correct bucket.
4. Publish a new brief from the dashboard → it appears immediately under its domain category and exact age chip.
