### PR TITLE
feat(book): add voice reading feature to BookPreface and BookReaderPage

### DIFF
--- a/client/src/components/book/BookPreface.tsx
+++ b/client/src/components/book/BookPreface.tsx
@@ -35,6 +35,8 @@ type CopyBundle = {
   readBody: string;
   paceTitle: string;
   paceBody: string;
+  voiceTitle: string;
+  voiceBody: string;
   beginLabel: string;
 };
 
@@ -49,6 +51,8 @@ const EN: CopyBundle = {
   readBody: "Tap the speaker to hear the page.",
   paceTitle: "No rush",
   paceBody: "Stay as long as you like.",
+  voiceTitle: "In your voice",
+  voiceBody: "Tap ‘Read in your voice’ to narrate the story yourself.",
   beginLabel: "Begin the story",
 };
 
@@ -63,6 +67,8 @@ const HE: CopyBundle = {
   readBody: "הקישו על הרמקול כדי לשמוע את הסיפור.",
   paceTitle: "ללא לחץ",
   paceBody: "הישארו על כל עמוד כמה שתרצו.",
+  voiceTitle: "בקול שלכם",
+  voiceBody: "הקישו על 'הקראה בקולכם' כדי לספר את הסיפור בעצמכם.",
   beginLabel: "להתחיל את הסיפור",
 };
 
@@ -77,6 +83,8 @@ const AR: CopyBundle = {
   readBody: "اضغطوا على السماعة لسماع الصفحة.",
   paceTitle: "دون استعجال",
   paceBody: "ابقوا على الصفحة كما تشاؤون.",
+  voiceTitle: "بصوتكم",
+  voiceBody: "اضغطوا على 'اقرأ بصوتك' لترووا القصة بأنفسكم.",
   beginLabel: "لنبدأ القصة",
 };
 
@@ -454,6 +462,38 @@ export default function BookPreface({
                 />
                 <path
                   d="M12 8v4l3 2"
+                  stroke={BOOK_COLORS.rose}
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                />
+              </svg>
+            }
+          />
+          <InstructionRow
+            isRTL={isRTL}
+            title={copy.voiceTitle}
+            body={copy.voiceBody}
+            icon={
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <rect
+                  x="9"
+                  y="2"
+                  width="6"
+                  height="12"
+                  rx="3"
+                  stroke={BOOK_COLORS.rose}
+                  strokeWidth="1.6"
+                  fill="none"
+                />
+                <path
+                  d="M5 11a7 7 0 0014 0"
+                  stroke={BOOK_COLORS.rose}
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  fill="none"
+                />
+                <path
+                  d="M12 18v4M9 22h6"
                   stroke={BOOK_COLORS.rose}
                   strokeWidth="1.6"
                   strokeLinecap="round"

--- a/client/src/pages/BookReaderPage.tsx
+++ b/client/src/pages/BookReaderPage.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Typography,
   IconButton,
   useTheme,
@@ -22,6 +23,7 @@ import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import MicIcon from "@mui/icons-material/Mic";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import PauseIcon from "@mui/icons-material/Pause";
 import StopIcon from "@mui/icons-material/Stop";
 import AutoplayIcon from "@mui/icons-material/PlayCircleOutline";
@@ -471,6 +473,9 @@ export default function BookReaderPage() {
         if (!cancelled) {
           setCaregiverVoiceId(profile.elevenLabsVoiceId);
           setUseClonedVoice(Boolean(profile.elevenLabsVoiceId));
+          if (!profile.elevenLabsVoiceId) {
+            setVoiceModalOpen(true);
+          }
         }
       } catch (err) {
         console.warn("[BookReader] Failed to load caregiver voice profile:", err);
@@ -1008,22 +1013,58 @@ export default function BookReaderPage() {
               <Tooltip title={autoRead ? tt("pages.bookReader.autoReadOn", "Auto-read on") : tt("pages.bookReader.autoReadOff", "Auto-read off")} arrow>
                 <IconButton onClick={() => setAutoRead((p) => !p)} sx={{ color: autoRead ? theme.palette.primary.main : theme.palette.text.primary }}><AutoplayIcon /></IconButton>
               </Tooltip>
-              {caregiverVoiceId ? (
-                <Tooltip title={useClonedVoice ? tt("pages.bookReader.useSystemVoice", "System voice") : tt("pages.bookReader.useMyVoice", "My voice")} arrow>
-                  <IconButton
-                    onClick={() => setUseClonedVoice((v) => !v)}
-                    sx={{ color: useClonedVoice ? theme.palette.primary.main : theme.palette.text.secondary, fontSize: "0.7rem", px: 1 }}
-                    aria-pressed={useClonedVoice}
-                  >
-                    {useClonedVoice ? tt("pages.bookReader.useMyVoice", "My voice") : tt("pages.bookReader.useSystemVoice", "System")}
-                  </IconButton>
-                </Tooltip>
+              {!caregiverVoiceId ? (
+                <Button
+                  size="small"
+                  startIcon={<MicIcon />}
+                  onClick={() => setVoiceModalOpen(true)}
+                  sx={{
+                    background: "#F5E6EA",
+                    color: "#824D5C",
+                    borderRadius: "20px",
+                    px: 2,
+                    py: 0.8,
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    textTransform: "none",
+                    border: "none",
+                    "&:hover": { background: "#EDD5DB" },
+                  }}
+                >
+                  {tt("pages.bookReader.readInYourVoice", "Read in your voice")}
+                </Button>
               ) : (
-                <Tooltip title={tt("pages.bookReader.recordMyVoice", "Record my voice")} arrow>
-                  <IconButton onClick={() => setVoiceModalOpen(true)} sx={{ color: theme.palette.text.primary }}>
-                    <MicIcon />
-                  </IconButton>
-                </Tooltip>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Box
+                    sx={{
+                      display: "flex", alignItems: "center", gap: "6px",
+                      px: 1.5, py: 0.7, borderRadius: "20px",
+                      background: "#F5E6EA", border: "1px solid #D8C0C8",
+                    }}
+                  >
+                    <Box sx={{ width: 7, height: 7, borderRadius: "50%", background: "#4CAF50" }} />
+                    <Typography sx={{ fontSize: "12px", color: "#824D5C", fontWeight: 500 }}>
+                      {tt("pages.bookReader.yourVoice", "Your voice")}
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    startIcon={isReading ? <PauseIcon /> : <PlayArrowIcon />}
+                    onClick={() => (isReading ? handleStopReading() : handleReadStory())}
+                    sx={{
+                      background: "#824D5C",
+                      color: "#fff",
+                      borderRadius: "20px",
+                      px: 2,
+                      fontSize: "13px",
+                      fontWeight: 500,
+                      textTransform: "none",
+                      "&:hover": { background: "#6B3D4A" },
+                    }}
+                  >
+                    {isReading ? tt("pages.bookReader.pause", "Pause") : tt("pages.bookReader.listen", "Listen")}
+                  </Button>
+                </Box>
               )}
               {showBrowserVoicePicker ? (
               <FormControl size="small" sx={{ minWidth: 180 }}>
@@ -1100,12 +1141,58 @@ export default function BookReaderPage() {
                       <IconButton onClick={() => setAutoRead((p) => !p)} sx={{ color: autoRead ? theme.palette.primary.main : theme.palette.text.primary }}><AutoplayIcon /></IconButton>
                     </Tooltip>
                     {!caregiverVoiceId ? (
-                      <Tooltip title={tt("pages.bookReader.recordMyVoice", "Record my voice")} arrow>
-                        <IconButton onClick={() => setVoiceModalOpen(true)} sx={{ color: theme.palette.text.primary }}>
-                          <MicIcon />
-                        </IconButton>
-                      </Tooltip>
-                    ) : null}
+                      <Button
+                        size="small"
+                        startIcon={<MicIcon />}
+                        onClick={() => setVoiceModalOpen(true)}
+                        sx={{
+                          background: "#F5E6EA",
+                          color: "#824D5C",
+                          borderRadius: "20px",
+                          px: 2,
+                          py: 0.8,
+                          fontSize: "13px",
+                          fontWeight: 500,
+                          textTransform: "none",
+                          border: "none",
+                          "&:hover": { background: "#EDD5DB" },
+                        }}
+                      >
+                        {tt("pages.bookReader.readInYourVoice", "Read in your voice")}
+                      </Button>
+                    ) : (
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        <Box
+                          sx={{
+                            display: "flex", alignItems: "center", gap: "6px",
+                            px: 1.5, py: 0.7, borderRadius: "20px",
+                            background: "#F5E6EA", border: "1px solid #D8C0C8",
+                          }}
+                        >
+                          <Box sx={{ width: 7, height: 7, borderRadius: "50%", background: "#4CAF50" }} />
+                          <Typography sx={{ fontSize: "12px", color: "#824D5C", fontWeight: 500 }}>
+                            {tt("pages.bookReader.yourVoice", "Your voice")}
+                          </Typography>
+                        </Box>
+                        <Button
+                          size="small"
+                          startIcon={isReading ? <PauseIcon /> : <PlayArrowIcon />}
+                          onClick={() => (isReading ? handleStopReading() : handleReadStory())}
+                          sx={{
+                            background: "#824D5C",
+                            color: "#fff",
+                            borderRadius: "20px",
+                            px: 2,
+                            fontSize: "13px",
+                            fontWeight: 500,
+                            textTransform: "none",
+                            "&:hover": { background: "#6B3D4A" },
+                          }}
+                        >
+                          {isReading ? tt("pages.bookReader.pause", "Pause") : tt("pages.bookReader.listen", "Listen")}
+                        </Button>
+                      </Box>
+                    )}
                     <Tooltip title={t("pages.bookReader.fullScreen")} arrow>
                       <IconButton onClick={toggleFullScreen} sx={{ color: theme.palette.text.primary }}><FullscreenIcon /></IconButton>
                     </Tooltip>


### PR DESCRIPTION
- Introduced new voice reading options in the BookPreface component, allowing users to narrate stories in their own voice.
- Updated the BookReaderPage to include buttons for reading in the user's voice, with appropriate UI enhancements and tooltips.
- Added internationalization support for new voice-related text in English, Hebrew, and Arabic, improving accessibility for multilingual users.