### PR TITLE
feat(stories): add language and personalization filters to story API …

### DIFF
--- a/client/src/api/stories.ts
+++ b/client/src/api/stories.ts
@@ -74,6 +74,10 @@ export type Story = {
   topicKey?: string;
   situationId?: string;
   isActive?: boolean;
+  /** Story output language: "en" | "he" | "ar". */
+  language?: string;
+  /** Whether this story supports child-name/photo personalization. */
+  personalizationEnabled?: boolean;
 };
 
 /**
@@ -108,6 +112,8 @@ function mapDocToStory(doc: { id: string; data: () => Record<string, any> }, lan
     targetAgeGroup: data.targetAgeGroup || data.ageGroup || data.generationConfig?.targetAgeGroup,
     topicKey: data.topicKey || data.primaryTopic,
     isActive: data.isActive,
+    language: data.language || data.generationConfig?.language,
+    personalizationEnabled: data.personalizationEnabled === true,
   };
 }
 
@@ -223,6 +229,10 @@ export interface StoryFilters {
   categoryId?: string;
   topicId?: string;
   situationIds?: string[]; // For category filtering - all situation IDs in that category
+  /** Story output language: "en" | "he" | "ar". Omit/empty for all languages. */
+  language?: string;
+  /** "personalized" | "not_personalized". Omit/empty for all. */
+  personalization?: "personalized" | "not_personalized";
 }
 
 /**
@@ -300,6 +310,17 @@ export async function fetchStoriesWithFilters(
           story.ageGroup || story.targetAgeGroup || story.generationConfig?.targetAgeGroup;
         return normalizeAgeGroup(storyAge) === normalizedFilterAge;
       });
+    }
+
+    if (filters.language) {
+      stories = stories.filter((story) => story.language === filters.language);
+    }
+
+    if (filters.personalization) {
+      const wantPersonalized = filters.personalization === "personalized";
+      stories = stories.filter(
+        (story) => Boolean(story.personalizationEnabled) === wantPersonalized
+      );
     }
 
     stories = stories.filter((story) => matchesTaxonomy(story, filters));

--- a/client/src/i18n/translations/ar.json
+++ b/client/src/i18n/translations/ar.json
@@ -280,7 +280,15 @@
     "years": "سنوات",
     "removeAria": "قم بإزالة مرشح {label}",
     "search": "بحث...",
-    "groupTopics": "المواضيع"
+    "groupTopics": "المواضيع",
+    "language": "اللغة",
+    "allLanguages": "كل اللغات",
+    "languageArabic": "العربية",
+    "languageHebrew": "العبرية",
+    "languageEnglish": "الإنجليزية",
+    "personalization": "التخصيص",
+    "personalizedOnly": "المخصصة فقط",
+    "notPersonalizedOnly": "غير المخصصة فقط"
   },
   "pages": {
     "ageResults": {

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -280,7 +280,15 @@
     "years": "years",
     "removeAria": "Remove {label} filter",
     "search": "Search...",
-    "groupTopics": "Topics"
+    "groupTopics": "Topics",
+    "language": "Language",
+    "allLanguages": "All languages",
+    "languageArabic": "Arabic",
+    "languageHebrew": "Hebrew",
+    "languageEnglish": "English",
+    "personalization": "Personalization",
+    "personalizedOnly": "Personalized only",
+    "notPersonalizedOnly": "Not personalized only"
   },
   "pages": {
     "ageResults": {

--- a/client/src/i18n/translations/he.json
+++ b/client/src/i18n/translations/he.json
@@ -280,7 +280,15 @@
     "years": "שנים",
     "removeAria": "הסר מסנן {label}",
     "search": "חיפוש...",
-    "groupTopics": "נושאים"
+    "groupTopics": "נושאים",
+    "language": "שפה",
+    "allLanguages": "כל השפות",
+    "languageArabic": "ערבית",
+    "languageHebrew": "עברית",
+    "languageEnglish": "אנגלית",
+    "personalization": "התאמה אישית",
+    "personalizedOnly": "מותאמים אישית בלבד",
+    "notPersonalizedOnly": "לא מותאמים אישית בלבד"
   },
   "pages": {
     "ageResults": {

--- a/client/src/pages/AllBooksPage.tsx
+++ b/client/src/pages/AllBooksPage.tsx
@@ -83,6 +83,8 @@ export default function AllBooksPage() {
   const [selectedAge, setSelectedAge] = useState<string>("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
   const [selectedTopic, setSelectedTopic] = useState<string>("");
+  const [selectedLanguage, setSelectedLanguage] = useState<string>("");
+  const [selectedPersonalization, setSelectedPersonalization] = useState<string>("");
   const t = useTranslation();
   const { language } = useLanguage();
   const { data: referenceData } = useReferenceData();
@@ -197,16 +199,38 @@ export default function AllBooksPage() {
       );
     }
 
+    if (selectedLanguage) {
+      filtered = filtered.filter((book) => (book as any).language === selectedLanguage);
+    }
+
+    if (selectedPersonalization) {
+      const wantPersonalized = selectedPersonalization === "personalized";
+      filtered = filtered.filter(
+        (book) => Boolean((book as any).personalizationEnabled) === wantPersonalized
+      );
+    }
+
     return filtered;
-  }, [allBooks, selectedAge, selectedCategory, selectedTopic]);
+  }, [
+    allBooks,
+    selectedAge,
+    selectedCategory,
+    selectedTopic,
+    selectedLanguage,
+    selectedPersonalization,
+  ]);
 
   const handleClearAll = () => {
     setSelectedAge("");
     setSelectedCategory("");
     setSelectedTopic("");
+    setSelectedLanguage("");
+    setSelectedPersonalization("");
   };
 
-  const hasActiveFilters = Boolean(selectedAge || selectedCategory || selectedTopic);
+  const hasActiveFilters = Boolean(
+    selectedAge || selectedCategory || selectedTopic || selectedLanguage || selectedPersonalization
+  );
 
   const graphCategoryLabel = t("filters.groupTopics");
 
@@ -274,10 +298,39 @@ export default function AllBooksPage() {
         }
       : null;
 
+  const languageGroup: FilterGroup = {
+    type: "chips",
+    key: "language",
+    label: t("filters.language"),
+    options: [
+      { value: "", label: t("filters.allLanguages") },
+      { value: "ar", label: t("filters.languageArabic") },
+      { value: "he", label: t("filters.languageHebrew") },
+      { value: "en", label: t("filters.languageEnglish") },
+    ],
+    value: selectedLanguage,
+    onChange: setSelectedLanguage,
+  };
+
+  const personalizationGroup: FilterGroup = {
+    type: "chips",
+    key: "personalization",
+    label: t("filters.personalization"),
+    options: [
+      { value: "", label: t("filters.all") },
+      { value: "personalized", label: t("filters.personalizedOnly") },
+      { value: "not_personalized", label: t("filters.notPersonalizedOnly") },
+    ],
+    value: selectedPersonalization,
+    onChange: setSelectedPersonalization,
+  };
+
   const filterGroups: FilterGroup[] = [
     ageGroup,
     categoryGroup,
     ...(topicGroup ? [topicGroup] : []),
+    languageGroup,
+    personalizationGroup,
   ];
 
   const containerSx = { px: { xs: 2, md: 4 }, py: 3 };

--- a/server/scripts/backfillStoryLanguage.ts
+++ b/server/scripts/backfillStoryLanguage.ts
@@ -1,0 +1,106 @@
+/**
+ * Backfill: correct `story_templates.generationConfig.language`.
+ *
+ * Why: `publishStory.ts` used to unconditionally hardcode this field to "he"
+ * at publish time, ignoring the specialist's chosen `brief.outputLanguage`
+ * entirely (fixed in the same change as this script). Every template
+ * published before that fix has the wrong value baked in. This script
+ * recovers the true language from each template's source `stories/{draftId}`
+ * draft document (`brief.outputLanguage`) and corrects it.
+ *
+ * Safe by design:
+ *   - Dry-run by default. Pass --apply to write.
+ *   - Idempotent: only writes when the derived language actually differs
+ *     from the current value.
+ *   - Never guesses — a template is reported as unresolved (and left alone)
+ *     if its source draft is missing or has no `brief.outputLanguage`.
+ *
+ * Run (dry-run): npx ts-node scripts/backfillStoryLanguage.ts
+ * Run (apply):   npx ts-node scripts/backfillStoryLanguage.ts --apply
+ */
+
+import { db } from "../src/config/firebase";
+import { STORIES_COLLECTION } from "../src/models/story.model";
+import { coerceStoryLanguage, type StoryLanguage } from "../src/models/storyBrief.model";
+
+const APPLY = process.argv.includes("--apply");
+
+async function run() {
+  console.log(
+    `🔧 Backfilling story_templates.generationConfig.language (${APPLY ? "APPLY" : "DRY-RUN"})\n`,
+  );
+
+  const templatesSnap = await db.collection("story_templates").get();
+  console.log(`   Found ${templatesSnap.size} templates\n`);
+
+  let alreadyCorrect = 0;
+  let fixed = 0;
+  let unresolved = 0;
+
+  for (const doc of templatesSnap.docs) {
+    const data = doc.data();
+    const currentLanguage = data.generationConfig?.language as string | undefined;
+    const draftId = (data.draftId || data.briefId || data.sourceStoryId) as string | undefined;
+
+    if (!draftId) {
+      console.log(
+        `   ⚠️  UNRESOLVED ${doc.id} ("${data.title}") — no draftId/briefId/sourceStoryId ` +
+          `to trace back to a source draft.`,
+      );
+      unresolved++;
+      continue;
+    }
+
+    const draftSnap = await db.collection(STORIES_COLLECTION).doc(draftId).get();
+    if (!draftSnap.exists) {
+      console.log(
+        `   ⚠️  UNRESOLVED ${doc.id} ("${data.title}") — source draft ` +
+          `${STORIES_COLLECTION}/${draftId} not found.`,
+      );
+      unresolved++;
+      continue;
+    }
+
+    const outputLanguage = draftSnap.data()?.brief?.outputLanguage;
+    if (!outputLanguage) {
+      console.log(
+        `   ⚠️  UNRESOLVED ${doc.id} ("${data.title}") — ${STORIES_COLLECTION}/${draftId} ` +
+          `has no brief.outputLanguage.`,
+      );
+      unresolved++;
+      continue;
+    }
+
+    const correctLanguage: StoryLanguage = coerceStoryLanguage(outputLanguage);
+
+    if (correctLanguage === currentLanguage) {
+      alreadyCorrect++;
+      continue;
+    }
+
+    console.log(
+      `   ✅ ${APPLY ? "PATCHED" : "WOULD PATCH"} ${doc.id} ("${data.title}"): ` +
+        `generationConfig.language "${currentLanguage}" → "${correctLanguage}" ` +
+        `(from ${STORIES_COLLECTION}/${draftId})`,
+    );
+    if (APPLY) {
+      await doc.ref.update({ "generationConfig.language": correctLanguage });
+    }
+    fixed++;
+  }
+
+  console.log(
+    `\n📊 ${fixed} ${APPLY ? "fixed" : "to fix"}, ${alreadyCorrect} already correct, ` +
+      `${unresolved} unresolved\n`,
+  );
+  if (!APPLY) {
+    console.log("ℹ️  Re-run with --apply to write these changes.\n");
+  }
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("❌ Backfill failed:", err);
+    process.exit(1);
+  });

--- a/server/src/illustration/orchestrator/publishStory.ts
+++ b/server/src/illustration/orchestrator/publishStory.ts
@@ -16,7 +16,7 @@ import {
   readLatestVisualBible,
 } from "@/illustration/shared/artefact-store";
 import { fillIllustrationV2DocDefaults, STORIES_COLLECTION, type Story } from "@/models/story.model";
-import type { AgeRange } from "@/models/storyBrief.model";
+import { coerceStoryLanguage, type AgeRange } from "@/models/storyBrief.model";
 import { COLLECTIONS } from "@/shared/firestore/paths";
 import { generateTextVariants } from "@/services/textVariants.service";
 import { checkReferenceItem } from "@/services/referenceData.service";
@@ -135,7 +135,7 @@ export async function publishStory(params: {
   const brief = story.brief;
   const ageRange = brief.ageAndScope.ageRange;
   const ageGroup = ageRange;
-  const language: "ar" | "he" = "he";
+  const language = coerceStoryLanguage(brief.outputLanguage);
   const isPersonalizable = brief.storyWorld.personalization === true;
 
   // ── Load Visual Bible (once) ──────────────────────────────────────────────

--- a/server/src/services/personalization.service.ts
+++ b/server/src/services/personalization.service.ts
@@ -1,5 +1,6 @@
 import { Gender } from "../shared/types/common";
 import { StoryTemplatePage } from "../shared/types/storyTemplate";
+import type { StoryLanguage } from "../models/storyBrief.model";
 
 // ============================================================================
 // Pronoun Sets
@@ -16,7 +17,7 @@ export interface ChildData {
   gender: Gender;
 }
 
-const PRONOUN_MAPS: Record<"he" | "ar", Record<Gender, PronounSet>> = {
+const PRONOUN_MAPS: Record<StoryLanguage, Record<Gender, PronounSet>> = {
   he: {
     male: {
       subject: "הוא",
@@ -41,6 +42,18 @@ const PRONOUN_MAPS: Record<"he" | "ar", Record<Gender, PronounSet>> = {
       possessive: "ها",
     },
   },
+  en: {
+    male: {
+      subject: "he",
+      object: "him",
+      possessive: "his",
+    },
+    female: {
+      subject: "she",
+      object: "her",
+      possessive: "her",
+    },
+  },
 };
 
 // ============================================================================
@@ -59,7 +72,7 @@ const CHARACTER_DESCRIPTIONS: Record<Gender, string> = {
 /**
  * Returns the pronoun set for a given gender and language.
  */
-export function getPronounSet(gender: Gender, language: "ar" | "he"): PronounSet {
+export function getPronounSet(gender: Gender, language: StoryLanguage): PronounSet {
   return PRONOUN_MAPS[language][gender];
 }
 
@@ -85,7 +98,7 @@ export function selectTextVariant(page: StoryTemplatePage, gender: Gender): stri
 export function personalizeText(
   template: string,
   child: ChildData,
-  language: "ar" | "he",
+  language: StoryLanguage,
 ): string {
   const pronouns = getPronounSet(child.gender, language);
 

--- a/server/src/shared/types/personalizedStory.ts
+++ b/server/src/shared/types/personalizedStory.ts
@@ -1,6 +1,7 @@
 import { Timestamp } from "firebase-admin/firestore";
 import { AgeGroup, Gender } from "./common";
 import type { IllustrationStyleId } from "./visualStyles";
+import type { StoryLanguage } from "../../models/storyBrief.model";
 
 export type StoryGenerationStatus = "pending" | "in_progress" | "completed" | "failed" | "partially_failed";
 
@@ -39,7 +40,7 @@ export interface PersonalizedStory {
   templateId: string;
   templateTitle: string;
   templateVersion: number;
-  language: "ar" | "he";
+  language: StoryLanguage;
   dedicationName: string | null;
 
   coverImageUrl: string;

--- a/server/src/shared/types/storyPreview.ts
+++ b/server/src/shared/types/storyPreview.ts
@@ -1,5 +1,6 @@
 import { Timestamp } from "firebase-admin/firestore";
 import { AgeGroup, Gender, PhotoStatus } from "./common";
+import type { StoryLanguage } from "../../models/storyBrief.model";
 
 /**
  * Discriminates how a preview's content was produced:
@@ -70,7 +71,7 @@ export interface StoryPreview {
   // --- Template snapshot ---
   templateTitle: string;
   templateVersion: number;
-  language: "ar" | "he";
+  language: StoryLanguage;
   dedicationName: string | null;
 
   // --- Preview content ---

--- a/server/src/shared/types/storyTemplate.ts
+++ b/server/src/shared/types/storyTemplate.ts
@@ -1,5 +1,5 @@
 import { Timestamp } from "firebase-admin/firestore";
-import type { AgeRange } from "../../models/storyBrief.model";
+import type { AgeRange, StoryLanguage } from "../../models/storyBrief.model";
 import type { IllustrationStyleId } from "./visualStyles";
 
 export interface LocalizedString {
@@ -158,7 +158,7 @@ export interface StoryTemplate {
    */
   ageGroup: AgeRange;
   generationConfig: {
-    language: "ar" | "he";
+    language: StoryLanguage;
     targetAgeGroup: string;
     length: string;
     tone: string;


### PR DESCRIPTION
…and UI

- Introduced `language` and `personalizationEnabled` properties to the Story type for enhanced filtering capabilities.
- Updated the story fetching logic to support filtering by language and personalization status.
- Added corresponding UI components for selecting language and personalization options in the AllBooksPage.
- Enhanced translations for language and personalization filters in Arabic, Hebrew, and English.